### PR TITLE
Fixed type check for callback function

### DIFF
--- a/spectro.js
+++ b/spectro.js
@@ -172,7 +172,7 @@ if (cluster.isMaster) {
 			return
 		}
 		this.__process()
-		if (typeof callback === 'Function') callback(null)
+		if (typeof callback === 'function') callback(null)
 	}
 
 	/**


### PR DESCRIPTION
The before calling the callback it is checked for the type "Function". This has to be lowercase in order to match as expected. This fixes issue #1 